### PR TITLE
Catch the strings K- & K. on kids_meal feature

### DIFF
--- a/heuristics/bin_3to5.py
+++ b/heuristics/bin_3to5.py
@@ -30,24 +30,24 @@ class Bin3to5Classifier:
             return True
         return False
     
-    def classify(self, orders):
+    def classify(self, table):
         # if table contains "K" as for kids - return FAMILY_EVENT
-        if any([order.kids_meal for idx, order in orders.iterrows()]):
+        if table["kids_meal"]:
             return FAMILY_EVENT
 
         # else if table contains kids-related items (pancakes, milkshake etc.) - return FAMILY_EVENT
         # TODO: create a list of kids-related items
 
         # else if table contains mostly alcoholic drinks w/o main dishes - return DRINKING
-        if orders.iloc[0]["total_orders_category_id_3.0"] > 0 and orders.iloc[0]["total_orders_category_id_2.0"] == 0:
+        if table["total_orders_category_id_3.0"] > 0 and table["total_orders_category_id_2.0"] == 0:
             return DRINKING
         # TODO: figure out WHAT ARE main dishes? (again, create a list / take the whole category_id 2)
 
         # else if table contains shareable dishes w/ drinks, return:
         # - AFTER_WORK if occurs around after-work hours (15-18) during the weekdays (Monday to Friday)
         # - SOCIAL_GATHERING anytime else
-        if any([order.sharable for idx, order in orders.iterrows()]):
-            if self._is_after_work(orders.iloc[0].order_day_of_week, orders.iloc[0].order_hour):
+        if table["sharable"]:
+            if self._is_after_work(table["order_day_of_week"], table["order_hour"]):
                 return AFTER_WORK
             return SOCIAL_GATHERING
         
@@ -57,7 +57,7 @@ class Bin3to5Classifier:
         # - LUNCH
         # - DINNER
         # TODO: use the pre-defined ToD table / generate a new one
-        if orders.iloc[0]["total_orders_category_id_2.0"] >= orders.iloc[0]["total_orders"] / 2:
-            return self._ToD(orders.iloc[0].order_hour)
+        if table["total_orders_category_id_2.0"] >= table["total_orders"] / 2:
+            return self._ToD(table.order_hour)
         
         return UNK


### PR DESCRIPTION
`kids_meal` feature is now truthy on the following scenarios (at least one of):
1. (lowercased) `title` contains `kid`
2. (lowercased) `title` starts with `k-`
3. (lowercased) `title` starts with `k.`